### PR TITLE
Visualization for the Chemformer

### DIFF
--- a/.codeboarding/Chemformer Core.md
+++ b/.codeboarding/Chemformer Core.md
@@ -1,0 +1,271 @@
+```mermaid
+
+graph LR
+
+    Main_Application_Entry_Points["Main Application Entry Points"]
+
+    Chemformer_Model_Core["Chemformer Model Core"]
+
+    Abstract_Transformer_Model["Abstract Transformer Model"]
+
+    Transformer_Model_Implementations["Transformer Model Implementations"]
+
+    Utility_Functions["Utility Functions"]
+
+    Retrosynthesis_Utilities["Retrosynthesis Utilities"]
+
+    Tokenizer_Building["Tokenizer Building"]
+
+    Data_Collection["Data Collection"]
+
+    Main_Application_Entry_Points -- "orchestrates" --> Chemformer_Model_Core
+
+    Main_Application_Entry_Points -- "uses" --> Utility_Functions
+
+    Main_Application_Entry_Points -- "uses" --> Retrosynthesis_Utilities
+
+    Main_Application_Entry_Points -- "uses" --> Tokenizer_Building
+
+    Chemformer_Model_Core -- "uses" --> Data_Collection
+
+    Chemformer_Model_Core -- "uses" --> Utility_Functions
+
+    Chemformer_Model_Core -- "initializes" --> Transformer_Model_Implementations
+
+    Transformer_Model_Implementations -- "inherits from" --> Abstract_Transformer_Model
+
+    Tokenizer_Building -- "uses" --> Utility_Functions
+
+    Data_Collection -- "uses" --> Utility_Functions
+
+    Retrosynthesis_Utilities -- "uses" --> Chemformer_Model_Core
+
+    Retrosynthesis_Utilities -- "uses" --> Utility_Functions
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Chemformer Core subsystem represents the central intelligence of the Chemformer project. It encompasses the main application entry points, the high-level Chemformer model, and the underlying transformer architectures (BART, Unified Transformer). This subsystem orchestrates various tasks such as training, prediction, and inference by leveraging the core neural network models. It interacts with utility functions for data handling, trainer utilities, and sampler implementations, as well as specialized retrosynthesis utilities. The core Chemformer model initializes and utilizes the specific transformer model implementations, which in turn inherit from an abstract transformer model, providing a structured and extensible architecture for molecular property prediction and retrosynthesis.
+
+
+
+### Main Application Entry Points
+
+These components represent the primary execution points for various tasks within the Chemformer system, including building tokenizers, performing inference, fine-tuning, pre-training, and predicting molecular properties. They orchestrate the overall flow of the application for their respective tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/build_tokenizer.py#L33-L55" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.build_tokenizer.main` (33:55)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/inference_score.py#L7-L21" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.inference_score.main` (7:21)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/fine_tune.py#L9-L18" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.fine_tune.main` (9:18)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/pretrain.py#L76-L118" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.pretrain.main` (76:118)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/predict.py#L30-L39" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.predict.main` (30:39)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_inference.py#L84-L105" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.retrosynthesis.round_trip_inference.main` (84:105)</a>
+
+
+
+
+
+### Chemformer Model Core
+
+This component encapsulates the core Chemformer model, handling its initialization, data module setup, model building (from scratch or checkpoint), and various operations like encoding, log-likelihood calculation, prediction, and scoring. It serves as the central interface for interacting with the Chemformer neural network.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L21-L647" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer` (21:647)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L248-L254" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.fit` (248:254)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L527-L569" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.predict` (527:569)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L571-L647" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.score_model` (571:647)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L402-L439" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.build_model` (402:439)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L152-L184" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.encode` (152:184)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L215-L246" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.set_datamodule` (215:246)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L259-L318" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer._random_initialization` (259:318)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L470-L511" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.log_likelihood` (470:511)</a>
+
+
+
+
+
+### Abstract Transformer Model
+
+This component defines the foundational structure and common functionalities for transformer-based models within Chemformer. It provides abstract methods and shared logic for training, validation, and testing steps, including forward passes, loss calculation, and token accuracy.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/base_transformer.py#L16-L294" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.base_transformer._AbsTransformerModel` (16:294)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/base_transformer.py#L99-L107" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.base_transformer._AbsTransformerModel.training_step` (99:107)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/base_transformer.py#L109-L129" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.base_transformer._AbsTransformerModel.validation_step` (109:129)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/base_transformer.py#L136-L158" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.base_transformer._AbsTransformerModel.test_step` (136:158)</a>
+
+
+
+
+
+### Transformer Model Implementations
+
+This component includes concrete implementations of transformer models, such as BART and Unified models, which inherit from the Abstract Transformer Model. They define the specific architecture and forward pass logic for their respective transformer variants.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/transformer_models.py#L17-L310" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.transformer_models.BARTModel` (17:310)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/transformer_models.py#L313-L512" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.transformer_models.UnifiedModel` (313:512)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/transformer_models.py#L78-L121" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.transformer_models.BARTModel.forward` (78:121)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/transformer_models.py#L365-L399" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.transformer_models.UnifiedModel.forward` (365:399)</a>
+
+
+
+
+
+### Utility Functions
+
+This component provides a collection of utility functions that support various aspects of the Chemformer system, including data handling, trainer utilities, and sampler implementations. These functions are generally stateless and perform specific, reusable tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/data_utils.py#L105-L106" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.data_utils.seed_everything` (105:106)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/data_utils.py#L42-L60" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.data_utils.build_molecule_datamodule` (42:60)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/trainer_utils.py#L74-L82" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.trainer_utils.calc_train_steps` (74:82)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_samplers.py#L162-L597" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_samplers.DecodeSampler` (162:597)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/trainer_utils.py#L85-L108" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.trainer_utils.build_trainer` (85:108)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L13-L133" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.ChemformerTokenizer` (13:133)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_samplers.py#L21-L159" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_samplers.BeamSearchSampler` (21:159)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/trainer_utils.py#L25-L34" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.trainer_utils.instantiate_scorers` (25:34)</a>
+
+
+
+
+
+### Retrosynthesis Utilities
+
+This component focuses on utilities specifically designed for retrosynthesis tasks, including creating round-trip datasets, setting output files, converting data formats, and computing round-trip accuracy. It supports the specialized workflow of retrosynthesis inference.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_inference.py#L17-L72" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.retrosynthesis.round_trip_inference.create_round_trip_dataset` (17:72)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_utils.py#L105-L109" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.retrosynthesis.round_trip_utils.set_output_files` (105:109)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_utils.py#L60-L102" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.retrosynthesis.round_trip_utils.convert_to_input_format` (60:102)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_utils.py#L7-L35" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.retrosynthesis.round_trip_utils.compute_round_trip_accuracy` (7:35)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_inference.py#L75-L80" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.retrosynthesis.round_trip_inference._run_test_callbacks` (75:80)</a>
+
+
+
+
+
+### Tokenizer Building
+
+This component is responsible for building and managing the tokenizer used by the Chemformer model. It includes functionalities for reading extra tokens and building unused tokens, which are crucial for preparing the vocabulary for the model.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/build_tokenizer.py#L9-L20" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.build_tokenizer.read_extra_tokens` (9:20)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/build_tokenizer.py#L23-L29" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.build_tokenizer.build_unused_tokens` (23:29)</a>
+
+
+
+
+
+### Data Collection
+
+This component handles the collection and management of data for the Chemformer model. It provides methods to retrieve data modules, which are essential for feeding data into the model during training, validation, and inference.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/data_collection.py#L18-L115" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.data_collection.DataCollection` (18:115)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/data_collection.py#L87-L92" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.data_collection.DataCollection.get_datamodule` (87:92)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data Processing.md
+++ b/.codeboarding/Data Processing.md
@@ -1,0 +1,293 @@
+```mermaid
+
+graph LR
+
+    Data_Processing["Data Processing"]
+
+    ChemformerModel["ChemformerModel"]
+
+    DataModuleHandler["DataModuleHandler"]
+
+    AbstractDataModule["AbstractDataModule"]
+
+    MoleculeDataModules["MoleculeDataModules"]
+
+    ReactionDataModules["ReactionDataModules"]
+
+    DataUtilities["DataUtilities"]
+
+    ChemformerModel -- "initializes and uses" --> DataModuleHandler
+
+    ChemformerModel -- "retrieves data from" --> AbstractDataModule
+
+    DataModuleHandler -- "instantiates" --> AbstractDataModule
+
+    MoleculeDataModules -- "inherits from" --> AbstractDataModule
+
+    ReactionDataModules -- "inherits from" --> AbstractDataModule
+
+    AbstractDataModule -- "utilizes" --> DataUtilities
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Data Processing subsystem is central to handling all data-related operations for the Chemformer model. It encompasses abstract and concrete data modules for various chemical datasets (molecules and reactions), a handler for managing these modules, and utility functions for data transformation and batching. The main flow involves the DataModuleHandler instantiating specific AbstractDataModule implementations, which then load, process, and split data, utilizing DataUtilities for tasks like batch encoding and attention mask generation. The ChemformerModel interacts with these data modules to retrieve prepared data for training, encoding, and prediction.
+
+
+
+### Data Processing
+
+This component is responsible for all aspects of data handling, including loading, processing, splitting, and preparing chemical datasets (e.g., ChEMBL, ZINC, USPTO) for model consumption. It manages data loaders, batch transformations, and provides utilities for data collection.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L73-L343" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule` (73:343)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/mol_data.py#L11-L31" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.mol_data.ChemblDataModule` (11:31)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/mol_data.py#L34-L50" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.mol_data.ZincDataModule` (34:50)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/datamodules.py#L6-L59" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.datamodules.SynthesisDataModule` (6:59)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L8-L42" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.Uspto50DataModule` (8:42)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L45-L66" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.UsptoMixedDataModule` (45:66)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L69-L98" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.UsptoSepDataModule` (69:98)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L101-L128" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.MolecularOptimizationDataModule` (101:128)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L346-L421" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.MoleculeListDataModule` (346:421)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L424-L487" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.ReactionListDataModule` (424:487)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L20-L70" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.ChemistryDataset` (20:70)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/data_collection.py#L1-L100" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.data_collection.DataCollection` (1:100)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/util.py#L7-L84" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.util.BatchEncoder` (7:84)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/zinc_utils.py#L56-L69" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.zinc_utils.read_zinc_slice` (56:69)</a>
+
+
+
+
+
+### ChemformerModel
+
+This component encapsulates the core Chemformer model, handling its initialization, training (fitting), encoding, decoding, prediction, and scoring. It manages the model's interaction with data loaders and the underlying BART/Unified models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L21-L647" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer` (21:647)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L27-L150" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.__init__` (27:150)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L152-L184" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.encode` (152:184)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L215-L246" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.set_datamodule` (215:246)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L470-L511" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.log_likelihood` (470:511)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L527-L569" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.predict` (527:569)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L571-L647" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.score_model` (571:647)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L441-L467" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.get_dataloader` (441:467)</a>
+
+
+
+
+
+### DataModuleHandler
+
+This component is responsible for collecting, loading, and providing access to various data modules used by the Chemformer model. It handles the configuration and instantiation of specific data modules based on the application's needs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/data_collection.py#L1-L100" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.data_collection.DataCollection` (1:100)</a>
+
+- `Chemformer.molbart.data.data_collection.DataCollection.__init__` (full file reference)
+
+- `Chemformer.molbart.data.data_collection.DataCollection.load_from_config` (full file reference)
+
+- `Chemformer.molbart.data.data_collection.DataCollection.get_datamodule` (full file reference)
+
+- `Chemformer.molbart.data.data_collection.DataCollection._set_datamodule_kwargs` (full file reference)
+
+
+
+
+
+### AbstractDataModule
+
+This abstract component defines the common interface and base functionalities for all specific data modules within the Chemformer project. It handles data loading, splitting, batching, and basic transformations, providing a standardized way to interact with different datasets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L73-L343" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule` (73:343)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L140-L164" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule.train_dataloader` (140:164)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L166-L173" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule.val_dataloader` (166:173)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L175-L182" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule.test_dataloader` (175:182)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L184-L195" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule.full_dataloader` (184:195)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L197-L200" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule.setup` (197:200)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L254-L255" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule._load_all_data` (254:255)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L313-L338" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule._split_dataset` (313:338)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L208-L226" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule._collate` (208:226)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L267-L295" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule._make_unified_model_batch` (267:295)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L205-L206" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule._build_attention_mask` (205:206)</a>
+
+
+
+
+
+### MoleculeDataModules
+
+This component represents concrete implementations of data modules specifically designed for handling molecular data, such as ChEMBL and ZINC datasets. They inherit from AbstractDataModule and implement dataset-specific loading and transformation logic.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/mol_data.py#L11-L31" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.mol_data.ChemblDataModule` (11:31)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/mol_data.py#L19-L25" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.mol_data.ChemblDataModule._load_all_data` (19:25)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/mol_data.py#L27-L31" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.mol_data.ChemblDataModule._transform_batch` (27:31)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/mol_data.py#L34-L50" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.mol_data.ZincDataModule` (34:50)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/mol_data.py#L42-L50" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.mol_data.ZincDataModule._load_all_data` (42:50)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L346-L421" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.MoleculeListDataModule` (346:421)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L375-L389" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.MoleculeListDataModule.__init__` (375:389)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L407-L421" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.MoleculeListDataModule._transform_batch` (407:421)</a>
+
+
+
+
+
+### ReactionDataModules
+
+This component encompasses concrete data modules tailored for reaction-based datasets, such as USPTO. Similar to MoleculeDataModules, they extend AbstractDataModule and provide specialized methods for loading and processing reaction data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L424-L487" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.ReactionListDataModule` (424:487)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L450-L454" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.ReactionListDataModule.__init__` (450:454)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L456-L457" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.ReactionListDataModule._build_attention_mask` (456:457)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L479-L487" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.ReactionListDataModule._transform_batch` (479:487)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/datamodules.py#L6-L59" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.datamodules.SynthesisDataModule` (6:59)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/datamodules.py#L22-L34" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.datamodules.SynthesisDataModule.__init__` (22:34)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/datamodules.py#L47-L59" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.datamodules.SynthesisDataModule._load_all_data` (47:59)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L8-L42" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.Uspto50DataModule` (8:42)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L16-L18" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.Uspto50DataModule.__init__` (16:18)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L35-L42" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.Uspto50DataModule._load_all_data` (35:42)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L60-L66" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.UsptoMixedDataModule._load_all_data` (60:66)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L91-L98" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.UsptoSepDataModule._load_all_data` (91:98)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L121-L128" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.MolecularOptimizationDataModule._load_all_data` (121:128)</a>
+
+
+
+
+
+### DataUtilities
+
+This component provides utility functions and classes that support data processing and batch encoding within the data modules. These utilities handle tasks like building attention masks, target masks, and encoding sequences for model input.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/data_utils.py#L42-L60" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.data_utils.build_molecule_datamodule` (42:60)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/util.py#L7-L84" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.util.BatchEncoder` (7:84)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/util.py#L43-L63" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.util.BatchEncoder.__call__` (43:63)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/util.py#L80-L84" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.util.BatchEncoder._pad_seqs` (80:84)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/util.py#L65-L77" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.util.BatchEncoder._check_seq_len` (65:77)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/util.py#L87-L102" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.util.build_attention_mask` (87:102)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/util.py#L105-L121" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.util.build_target_mask` (105:121)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Model Utilities.md
+++ b/.codeboarding/Model Utilities.md
@@ -1,0 +1,317 @@
+```mermaid
+
+graph LR
+
+    Model_Utilities["Model Utilities"]
+
+    TrainerManagement["TrainerManagement"]
+
+    MoleculeSamplingDecoding["MoleculeSamplingDecoding"]
+
+    TrainingCallbacks["TrainingCallbacks"]
+
+    PerformanceScoring["PerformanceScoring"]
+
+    BaseCollectionUtilities["BaseCollectionUtilities"]
+
+    SMILESUtilities["SMILESUtilities"]
+
+    MainApplicationFlow["MainApplicationFlow"]
+
+    DataManagement["DataManagement"]
+
+    ChemformerModel["ChemformerModel"]
+
+    MainApplicationFlow -- "configures" --> TrainerManagement
+
+    MainApplicationFlow -- "initializes" --> MoleculeSamplingDecoding
+
+    MainApplicationFlow -- "uses" --> ChemformerModel
+
+    MainApplicationFlow -- "uses" --> DataManagement
+
+    TrainerManagement -- "instantiates" --> TrainingCallbacks
+
+    TrainerManagement -- "instantiates" --> PerformanceScoring
+
+    ChemformerModel -- "configures" --> TrainerManagement
+
+    MoleculeSamplingDecoding -- "uses" --> SMILESUtilities
+
+    MoleculeSamplingDecoding -- "uses" --> PerformanceScoring
+
+    ChemformerModel -- "uses" --> MoleculeSamplingDecoding
+
+    TrainingCallbacks -- "uses" --> BaseCollectionUtilities
+
+    PerformanceScoring -- "uses" --> BaseCollectionUtilities
+
+    PerformanceScoring -- "uses" --> SMILESUtilities
+
+    ChemformerModel -- "integrates" --> PerformanceScoring
+
+    DataManagement -- "uses" --> BaseCollectionUtilities
+
+    Model_Utilities -- "contains" --> TrainerManagement
+
+    Model_Utilities -- "contains" --> MoleculeSamplingDecoding
+
+    Model_Utilities -- "contains" --> TrainingCallbacks
+
+    Model_Utilities -- "contains" --> PerformanceScoring
+
+    Model_Utilities -- "contains" --> BaseCollectionUtilities
+
+    Model_Utilities -- "contains" --> SMILESUtilities
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Model Utilities component provides a comprehensive set of functionalities crucial for the training, inference, and evaluation of the Chemformer model. It encapsulates sub-components responsible for managing the PyTorch Lightning Trainer configuration, implementing diverse molecule sampling and decoding strategies (including beam search), defining and aggregating performance metrics, and offering foundational utilities for dynamic class loading and SMILES string manipulation. This component is central to the Chemformer's operational pipeline, ensuring robust model training, accurate molecule generation, and thorough performance assessment.
+
+
+
+### Model Utilities
+
+This overarching component provides a suite of utilities that support the training, inference, and evaluation processes of the Chemformer model. It encompasses functionalities for building and configuring the PyTorch Lightning Trainer, implementing various sampling and decoding strategies (like beam search), defining metrics for scoring and evaluating model performance, and providing foundational collection and SMILES string manipulation utilities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Chemformer.molbart.utils.trainer_utils` (full file reference)
+
+- `Chemformer.molbart.utils.samplers` (full file reference)
+
+- `Chemformer.molbart.utils.callbacks` (full file reference)
+
+- `Chemformer.molbart.utils.scores` (full file reference)
+
+- `Chemformer.molbart.utils.base_collection` (full file reference)
+
+- `Chemformer.molbart.utils.smiles_utils` (full file reference)
+
+
+
+
+
+### TrainerManagement
+
+Manages the configuration and construction of the PyTorch Lightning training environment, including calculating training steps, and instantiating loggers, callbacks, and plugins for the training process. It is a core part of the Model Utilities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/trainer_utils.py#L85-L108" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.trainer_utils.build_trainer` (85:108)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/trainer_utils.py#L13-L22" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.trainer_utils.instantiate_callbacks` (13:22)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/trainer_utils.py#L74-L82" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.trainer_utils.calc_train_steps` (74:82)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/trainer_utils.py#L37-L52" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.trainer_utils.instantiate_logger` (37:52)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/trainer_utils.py#L55-L71" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.trainer_utils.instantiate_plugins` (55:71)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/trainer_utils.py#L25-L34" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.trainer_utils.instantiate_scorers` (25:34)</a>
+
+
+
+
+
+### MoleculeSamplingDecoding
+
+Provides functionalities for generating and decoding molecules, implementing various sampling strategies such as greedy and beam search, and managing the search process through nodes and termination conditions. It is a core part of the Model Utilities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_samplers.py#L162-L597" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_samplers.DecodeSampler` (162:597)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_samplers.py#L21-L159" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_samplers.BeamSearchSampler` (21:159)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_utils.py#L4-L184" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_utils.Node` (4:184)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_utils.py#L218-L224" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_utils.LogicalOr` (218:224)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_utils.py#L192-L198" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_utils.MaxLength` (192:198)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_utils.py#L201-L206" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_utils.EOS` (201:206)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_utils.py#L227-L241" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_utils.beamsearch` (227:241)</a>
+
+
+
+
+
+### TrainingCallbacks
+
+Offers a collection of callback mechanisms that can be invoked at different stages of the training lifecycle, such as saving model checkpoints and logging validation scores. It is a core part of the Model Utilities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/callbacks/callback_collection.py#L1-L100" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.callbacks.callback_collection.CallbackCollection` (1:100)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/callbacks/callbacks.py#L60-L102" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.callbacks.callbacks.StepCheckpoint` (60:102)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/callbacks/callbacks.py#L123-L184" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.callbacks.callbacks.ValidationScoreCallback` (123:184)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/callbacks/callbacks.py#L187-L253" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.callbacks.callbacks.ScoreCallback` (187:253)</a>
+
+
+
+
+
+### PerformanceScoring
+
+Defines and aggregates various metrics to evaluate the quality and diversity of generated molecules, including invalid fraction, uniqueness, Tanimoto similarity, and top-k accuracy. It is a core part of the Model Utilities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/score_collection.py#L19-L100" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.score_collection.ScoreCollection` (19:100)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/scores.py#L9-L30" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.scores.BaseScore` (9:30)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/scores.py#L33-L66" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.scores.FractionInvalidScore` (33:66)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/scores.py#L69-L107" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.scores.FractionUniqueScore` (69:107)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/scores.py#L110-L165" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.scores.TanimotoSimilarityScore` (110:165)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/scores.py#L168-L217" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.scores.TopKAccuracyScore` (168:217)</a>
+
+
+
+
+
+### BaseCollectionUtilities
+
+Provides foundational utilities for managing collections of objects, particularly for dynamically loading and instantiating classes from configuration, serving as a base for other collection components within Model Utilities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Chemformer.molbart.utils.base_collection.BaseCollection` (full file reference)
+
+
+
+
+
+### SMILESUtilities
+
+Contains helper functions for processing and manipulating SMILES strings, such as canonicalization, generating InChI keys, and uniqueifying sampled SMILES. It is a core part of the Model Utilities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/smiles_utils.py#L40-L81" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.smiles_utils.uniqueify_sampled_smiles` (40:81)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/smiles_utils.py#L25-L37" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.smiles_utils.inchi_key` (25:37)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/smiles_utils.py#L7-L22" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.smiles_utils.canonicalize_smiles` (7:22)</a>
+
+
+
+
+
+### MainApplicationFlow
+
+Orchestrates the entire pre-training process for the Chemformer model, including setting up the tokeniser, data module, model, and trainer, and initiating the training run.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/pretrain.py#L76-L118" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.pretrain.main` (76:118)</a>
+
+
+
+
+
+### DataManagement
+
+Responsible for handling the data pipeline, including loading datasets and preparing data modules for training and evaluation, often by dynamically loading data sources from configuration.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Chemformer.molbart.data.data_collection.DataCollection` (full file reference)
+
+
+
+
+
+### ChemformerModel
+
+Represents the core Chemformer model, which integrates various components like samplers, scorers, and trainer utilities to perform molecular generation and property prediction tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L21-L647" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer` (21:647)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Retrosynthesis Specifics.md
+++ b/.codeboarding/Retrosynthesis Specifics.md
@@ -1,0 +1,159 @@
+```mermaid
+
+graph LR
+
+    Retrosynthesis_Specifics["Retrosynthesis Specifics"]
+
+    RoundTripInferenceOrchestrator["RoundTripInferenceOrchestrator"]
+
+    DataPreparationAndMetrics["DataPreparationAndMetrics"]
+
+    ChemformerModel["ChemformerModel"]
+
+    DisconnectionAtomMapper["DisconnectionAtomMapper"]
+
+    RoundTripInferenceOrchestrator -- "orchestrates" --> ChemformerModel
+
+    RoundTripInferenceOrchestrator -- "orchestrates" --> DataPreparationAndMetrics
+
+    RoundTripInferenceOrchestrator -- "utilizes" --> DisconnectionAtomMapper
+
+    Retrosynthesis_Specifics -- "provides utilities for" --> DataPreparationAndMetrics
+
+    Retrosynthesis_Specifics -- "provides utilities for" --> DisconnectionAtomMapper
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This component overview details the structure and interactions of key modules involved in the retrosynthesis process within the Chemformer project. It highlights how the `RoundTripInferenceOrchestrator` manages the overall workflow, leveraging `DataPreparationAndMetrics` for data handling and evaluation, the `ChemformerModel` for core prediction tasks, and the `DisconnectionAtomMapper` for specialized atom mapping functionalities. The `Retrosynthesis Specifics` component provides utilities tailored for retrosynthesis, including data conversion and atom mapping.
+
+
+
+### Retrosynthesis Specifics
+
+This specialized component provides utilities and functionalities specifically tailored for retrosynthesis tasks within the Chemformer project. It handles data conversion to specific input formats and manages atom mapping for accurate reaction predictions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_utils.py#L60-L102" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.retrosynthesis.round_trip_utils.convert_to_input_format` (60:102)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/disconnection_aware/disconnection_atom_mapper.py#L13-L161" target="_blank" rel="noopener noreferrer">`molbart.retrosynthesis.disconnection_aware.disconnection_atom_mapper.DisconnectionAtomMapper` (13:161)</a>
+
+
+
+
+
+### RoundTripInferenceOrchestrator
+
+Manages the overall flow of the round-trip inference process for retrosynthesis, including dataset creation, model initialization, prediction execution, and integration with metric computation and callbacks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Chemformer.molbart.retrosynthesis.round_trip_inference.main` (full file reference)
+
+- `Chemformer.molbart.retrosynthesis.round_trip_inference.create_round_trip_dataset` (full file reference)
+
+- `Chemformer.molbart.retrosynthesis.round_trip_inference._run_test_callbacks` (full file reference)
+
+
+
+
+
+### DataPreparationAndMetrics
+
+Handles the preparation and formatting of input and output data for the round-trip inference, including batching, and is responsible for computing and reporting accuracy metrics based on the model's predictions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_utils.py#L60-L102" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.retrosynthesis.round_trip_utils.convert_to_input_format` (60:102)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_utils.py#L38-L57" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.retrosynthesis.round_trip_utils.batchify` (38:57)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_utils.py#L105-L109" target="_blank" rel="noopener noreferrer">`molbart.retrosynthesis.round_trip_utils.set_output_files` (105:109)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_utils.py#L7-L35" target="_blank" rel="noopener noreferrer">`molbart.retrosynthesis.round_trip_utils.compute_round_trip_accuracy` (7:35)</a>
+
+
+
+
+
+### ChemformerModel
+
+Represents the core Chemformer model, providing functionalities for loading, initializing, and performing predictions on chemical data, which are central to the retrosynthesis task.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L21-L647" target="_blank" rel="noopener noreferrer">`molbart.models.chemformer.Chemformer` (21:647)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L527-L569" target="_blank" rel="noopener noreferrer">`molbart.models.chemformer.Chemformer.predict` (527:569)</a>
+
+
+
+
+
+### DisconnectionAtomMapper
+
+Manages the complex logic of atom mapping within retrosynthesis, specifically handling operations like removing atom mappings, propagating input mappings to reactants, and canonicalizing mapped structures to ensure consistency.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/disconnection_aware/disconnection_atom_mapper.py#L13-L161" target="_blank" rel="noopener noreferrer">`molbart.retrosynthesis.disconnection_aware.disconnection_atom_mapper.DisconnectionAtomMapper` (13:161)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/disconnection_aware/disconnection_atom_mapper.py#L31-L58" target="_blank" rel="noopener noreferrer">`molbart.retrosynthesis.disconnection_aware.disconnection_atom_mapper.DisconnectionAtomMapper.predictions_atom_mapping` (31:58)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/disconnection_aware/disconnection_atom_mapper.py#L102-L115" target="_blank" rel="noopener noreferrer">`molbart.retrosynthesis.disconnection_aware.disconnection_atom_mapper.DisconnectionAtomMapper.remove_atom_mapping` (102:115)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/disconnection_aware/disconnection_atom_mapper.py#L60-L100" target="_blank" rel="noopener noreferrer">`molbart.retrosynthesis.disconnection_aware.disconnection_atom_mapper.DisconnectionAtomMapper.propagate_input_mapping_to_reactants` (60:100)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/disconnection_aware/disconnection_atom_mapper.py#L137-L148" target="_blank" rel="noopener noreferrer">`molbart.retrosynthesis.disconnection_aware.disconnection_atom_mapper.DisconnectionAtomMapper._canonicalize_mapped` (137:148)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/disconnection_aware/disconnection_atom_mapper.py#L150-L161" target="_blank" rel="noopener noreferrer">`molbart.retrosynthesis.disconnection_aware.disconnection_atom_mapper.DisconnectionAtomMapper._reaction_smiles_lst` (150:161)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/disconnection_aware/disconnection_atom_mapper.py#L20-L29" target="_blank" rel="noopener noreferrer">`molbart.retrosynthesis.disconnection_aware.disconnection_atom_mapper.DisconnectionAtomMapper.mapping_to_index` (20:29)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Tokenization.md
+++ b/.codeboarding/Tokenization.md
@@ -1,0 +1,177 @@
+```mermaid
+
+graph LR
+
+    ChemformerTokenizer["ChemformerTokenizer"]
+
+    TokensMasker["TokensMasker"]
+
+    ReplaceTokensMasker["ReplaceTokensMasker"]
+
+    SpanTokensMasker["SpanTokensMasker"]
+
+    ChemformerModel["ChemformerModel"]
+
+    ReplaceTokensMasker -- "inherits from" --> TokensMasker
+
+    SpanTokensMasker -- "inherits from" --> TokensMasker
+
+    TokensMasker -- "uses" --> ChemformerTokenizer
+
+    ChemformerModel -- "uses" --> ChemformerTokenizer
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This component specializes in converting chemical structures (SMILES) into numerical tokens, which is a prerequisite for the transformer models. It also implements various masking strategies (e.g., random token replacement, span masking) essential for pre-training objectives.
+
+
+
+### ChemformerTokenizer
+
+This component is responsible for converting chemical structures (SMILES) into numerical tokens and managing the vocabulary, including special tokens like start, end, mask, and separation tokens. It extends `pysmilesutils.tokenize.SMILESTokenizer` and distinguishes between chemical and non-chemical tokens.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L13-L133" target="_blank" rel="noopener noreferrer">`molbart.utils.tokenizers.tokenizers.ChemformerTokenizer` (13:133)</a>
+
+
+
+
+
+### TokensMasker
+
+This is an abstract base class that defines the common interface for token masking strategies. It orchestrates the masking process, including the addition of start and end special tokens, and delegates the specific masking logic to its subclasses. It depends on `ChemformerTokenizer` to perform its operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L136-L179" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.TokensMasker` (136:179)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L148-L149" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.TokensMasker.__call__` (148:149)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L151-L176" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.TokensMasker.mask_tokens` (151:176)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L178-L179" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.TokensMasker._apply_mask` (178:179)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L139-L146" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.TokensMasker.__init__` (139:146)</a>
+
+
+
+
+
+### ReplaceTokensMasker
+
+This component implements a token masking strategy where selected tokens are replaced with either a special mask token or a random chemical token, based on a defined probability. It extends the `TokensMasker` base class.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L182-L219" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.ReplaceTokensMasker` (182:219)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L194-L201" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.ReplaceTokensMasker.__init__` (194:201)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L203-L208" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.ReplaceTokensMasker._apply_mask` (203:208)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L210-L219" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.ReplaceTokensMasker._mask_token` (210:219)</a>
+
+
+
+
+
+### SpanTokensMasker
+
+This component implements a token masking strategy that masks a contiguous span of tokens. The length of the span is determined by a Poisson distribution. It extends the `TokensMasker` base class.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L222-L266" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.SpanTokensMasker` (222:266)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L234-L241" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.SpanTokensMasker.__init__` (234:241)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L243-L266" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.SpanTokensMasker._apply_mask` (243:266)</a>
+
+
+
+
+
+### ChemformerModel
+
+This is the main Chemformer model component responsible for building, fine-tuning, predicting, and scoring chemical reactions. It initializes with a tokenizer (specifically `ChemformerTokenizer`), builds the underlying BART or Unified model, and manages training and inference workflows, including data handling and model evaluation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L21-L647" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer` (21:647)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L27-L150" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.__init__` (27:150)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L152-L184" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.encode` (152:184)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L186-L213" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.decode` (186:213)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L215-L246" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.set_datamodule` (215:246)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L248-L254" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.fit` (248:254)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L256-L257" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.parameters` (256:257)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L259-L318" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer._random_initialization` (259:318)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L320-L400" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer._initialize_from_ckpt` (320:400)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L402-L439" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.build_model` (402:439)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L441-L467" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.get_dataloader` (441:467)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L470-L511" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.log_likelihood` (470:511)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L513-L525" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.on_device` (513:525)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L527-L569" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.predict` (527:569)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L571-L647" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.score_model` (571:647)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,261 @@
+```mermaid
+
+graph LR
+
+    Chemformer_Core["Chemformer Core"]
+
+    Data_Processing["Data Processing"]
+
+    Tokenization["Tokenization"]
+
+    Model_Utilities["Model Utilities"]
+
+    Retrosynthesis_Specifics["Retrosynthesis Specifics"]
+
+    Chemformer_Core -- "Consumes Data" --> Data_Processing
+
+    Chemformer_Core -- "Utilizes Tokenizers" --> Tokenization
+
+    Chemformer_Core -- "Orchestrates Operations" --> Model_Utilities
+
+    Chemformer_Core -- "Integrates Retrosynthesis" --> Retrosynthesis_Specifics
+
+    Data_Processing -- "Provides Raw Input" --> Tokenization
+
+    Tokenization -- "Returns Tokenized Output" --> Data_Processing
+
+    Model_Utilities -- "Performs Decoding" --> Tokenization
+
+    Model_Utilities -- "Accesses Data Loaders" --> Data_Processing
+
+    click Chemformer_Core href "https://github.com/MolecularAI/Chemformer/blob/main/.codeboarding//Chemformer Core.md" "Details"
+
+    click Data_Processing href "https://github.com/MolecularAI/Chemformer/blob/main/.codeboarding//Data Processing.md" "Details"
+
+    click Tokenization href "https://github.com/MolecularAI/Chemformer/blob/main/.codeboarding//Tokenization.md" "Details"
+
+    click Model_Utilities href "https://github.com/MolecularAI/Chemformer/blob/main/.codeboarding//Model Utilities.md" "Details"
+
+    click Retrosynthesis_Specifics href "https://github.com/MolecularAI/Chemformer/blob/main/.codeboarding//Retrosynthesis Specifics.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Chemformer project is designed for chemical language modeling, leveraging transformer architectures to process and generate chemical structures (SMILES). The core functionality revolves around a central Chemformer model that handles training, prediction, and inference tasks. Data is managed by a dedicated processing component, which prepares chemical datasets and interacts with a tokenization component to convert SMILES into numerical representations. Various utilities support the model's operations, including training management, molecule generation strategies, and performance evaluation metrics. Additionally, a specialized component addresses specific retrosynthesis tasks.
+
+
+
+### Chemformer Core
+
+This component represents the central intelligence of the Chemformer project, encompassing the main application entry points, the high-level `Chemformer` model, and the underlying transformer architectures (BART, Unified Transformer). It orchestrates various tasks like training, prediction, and inference, leveraging the core neural network models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/build_tokenizer.py#L33-L55" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.build_tokenizer.main` (33:55)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/inference_score.py#L7-L21" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.inference_score.main` (7:21)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/fine_tune.py#L9-L18" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.fine_tune.main` (9:18)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/pretrain.py#L76-L118" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.pretrain.main` (76:118)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/predict.py#L30-L39" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.predict.main` (30:39)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_inference.py#L1-L100" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.retrosynthesis.round_trip_inference.main` (1:100)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L21-L647" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer` (21:647)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L248-L254" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.fit` (248:254)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L527-L569" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.predict` (527:569)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L571-L647" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.score_model` (571:647)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L402-L439" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.build_model` (402:439)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L152-L184" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.encode` (152:184)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L215-L246" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.set_datamodule` (215:246)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L259-L318" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer._random_initialization` (259:318)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/chemformer.py#L470-L511" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.chemformer.Chemformer.log_likelihood` (470:511)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/transformer_models.py#L17-L310" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.transformer_models.BARTModel` (17:310)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/transformer_models.py#L313-L512" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.transformer_models.UnifiedModel` (313:512)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/base_transformer.py#L16-L294" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.base_transformer._AbsTransformerModel` (16:294)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/base_transformer.py#L99-L107" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.base_transformer._AbsTransformerModel.training_step` (99:107)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/base_transformer.py#L109-L129" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.base_transformer._AbsTransformerModel.validation_step` (109:129)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/base_transformer.py#L136-L158" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.base_transformer._AbsTransformerModel.test_step` (136:158)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/transformer_models.py#L78-L121" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.transformer_models.BARTModel.forward` (78:121)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/models/transformer_models.py#L365-L399" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.models.transformer_models.UnifiedModel.forward` (365:399)</a>
+
+
+
+
+
+### Data Processing
+
+This component is responsible for all aspects of data handling, including loading, processing, splitting, and preparing chemical datasets (e.g., ChEMBL, ZINC, USPTO) for model consumption. It manages data loaders, batch transformations, and provides utilities for data collection.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L73-L343" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base._AbsDataModule` (73:343)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/mol_data.py#L11-L31" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.mol_data.ChemblDataModule` (11:31)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/mol_data.py#L34-L50" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.mol_data.ZincDataModule` (34:50)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/datamodules.py#L6-L59" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.datamodules.SynthesisDataModule` (6:59)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L8-L42" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.Uspto50DataModule` (8:42)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L45-L66" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.UsptoMixedDataModule` (45:66)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L69-L98" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.UsptoSepDataModule` (69:98)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/seq2seq_data.py#L101-L128" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.seq2seq_data.MolecularOptimizationDataModule` (101:128)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L346-L421" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.MoleculeListDataModule` (346:421)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L424-L487" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.ReactionListDataModule` (424:487)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/base.py#L20-L70" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.base.ChemistryDataset` (20:70)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/data_collection.py#L1-L100" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.data_collection.DataCollection` (1:100)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/util.py#L7-L84" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.util.BatchEncoder` (7:84)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/data/zinc_utils.py#L56-L69" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.data.zinc_utils.read_zinc_slice` (56:69)</a>
+
+
+
+
+
+### Tokenization
+
+This component specializes in converting chemical structures (SMILES) into numerical tokens, which is a prerequisite for the transformer models. It also implements various masking strategies (e.g., random token replacement, span masking) essential for pre-training objectives.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L136-L179" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.TokensMasker` (136:179)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L182-L219" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.ReplaceTokensMasker` (182:219)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L222-L266" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.tokenizers.tokenizers.SpanTokensMasker` (222:266)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/tokenizers/tokenizers.py#L13-L133" target="_blank" rel="noopener noreferrer">`molbart.utils.tokenizers.tokenizers.ChemformerTokenizer` (13:133)</a>
+
+
+
+
+
+### Model Utilities
+
+This component provides a suite of utilities that support the training, inference, and evaluation processes of the Chemformer model. This includes functions for building and configuring the PyTorch Lightning Trainer, implementing various sampling and decoding strategies (like beam search), and defining metrics for scoring and evaluating model performance.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/trainer_utils.py#L85-L108" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.trainer_utils.build_trainer` (85:108)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/trainer_utils.py#L13-L22" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.trainer_utils.instantiate_callbacks` (13:22)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/callbacks/callback_collection.py#L1-L100" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.callbacks.callback_collection.CallbackCollection` (1:100)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/callbacks/callbacks.py#L60-L102" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.callbacks.callbacks.StepCheckpoint` (60:102)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/callbacks/callbacks.py#L123-L184" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.callbacks.callbacks.ValidationScoreCallback` (123:184)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/callbacks/callbacks.py#L187-L253" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.callbacks.callbacks.ScoreCallback` (187:253)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_samplers.py#L162-L597" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_samplers.DecodeSampler` (162:597)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_samplers.py#L21-L159" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_samplers.BeamSearchSampler` (21:159)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_utils.py#L4-L184" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.samplers.beam_search_utils.Node` (4:184)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_utils.py#L218-L224" target="_blank" rel="noopener noreferrer">`molbart.utils.samplers.beam_search_utils.LogicalOr` (218:224)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_utils.py#L192-L198" target="_blank" rel="noopener noreferrer">`molbart.utils.samplers.beam_search_utils.MaxLength` (192:198)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/samplers/beam_search_utils.py#L201-L206" target="_blank" rel="noopener noreferrer">`molbart.utils.samplers.beam_search_utils.EOS` (201:206)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/score_collection.py#L19-L100" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.score_collection.ScoreCollection` (19:100)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/scores.py#L9-L30" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.scores.BaseScore` (9:30)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/scores.py#L33-L66" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.scores.FractionInvalidScore` (33:66)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/scores.py#L69-L107" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.scores.FractionUniqueScore` (69:107)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/scores.py#L110-L165" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.scores.TanimotoSimilarityScore` (110:165)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/utils/scores/scores.py#L168-L217" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.utils.scores.scores.TopKAccuracyScore` (168:217)</a>
+
+
+
+
+
+### Retrosynthesis Specifics
+
+This specialized component provides utilities and functionalities specifically tailored for retrosynthesis tasks within the Chemformer project. It handles data conversion to specific input formats and manages atom mapping for accurate reaction predictions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/round_trip_utils.py#L60-L102" target="_blank" rel="noopener noreferrer">`Chemformer.molbart.retrosynthesis.round_trip_utils.convert_to_input_format` (60:102)</a>
+
+- <a href="https://github.com/MolecularAI/Chemformer/blob/master/molbart/retrosynthesis/disconnection_aware/disconnection_atom_mapper.py#L13-L161" target="_blank" rel="noopener noreferrer">`molbart.retrosynthesis.disconnection_aware.disconnection_atom_mapper.DisconnectionAtomMapper` (13:161)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR contains high-level diagrams for the Chemformer codebase. You can see how they render in Github here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/Chemformer/on_boarding.md

These diagrams are designed to help people quickly understand a codebase. At MolecularAI (AstraZeneca), where many scientists collaborate, our goal is to reduce the time it takes to get up to speed with someone elses codebase - from hours to just minutes - by using visuals instead of reading through the entire code. I'd love to hear how do you go about introducing people to codebases in MolecularAI.

We’d love any feedback! We also just released a free GitHub Action that can automatically update the diagrams.

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.